### PR TITLE
Add a leading / to match sops file pattern

### DIFF
--- a/hooks/forbid_secrets.py
+++ b/hooks/forbid_secrets.py
@@ -4,7 +4,7 @@ import argparse
 import re
 import sys
 
-SECRET_FILE_REGEX = "secrets"
+SECRET_FILE_REGEX = "/secrets"
 SOPS_REGEX = r"AES256"
 
 def contains_secret(filename):


### PR DESCRIPTION
Prevent check from failing due to filenames with word "secret" but with no actual secrets.